### PR TITLE
Irregular embedding improvements

### DIFF
--- a/Import-RegEx.ps1
+++ b/Import-RegEx.ps1
@@ -260,7 +260,12 @@
                 if ($importInvocation.InvocationName -eq '&' -or $importInvocation.InvocationName -eq '.') { return }
                 $foundAlias =
                     if ($ModuleCaller) {
-                        $ModuleCaller.ExportedAliases["?<$($regex.Name)>"]
+                        if ($ModuleCaller -and $ModuleCaller.ExportedAliases.Count) {
+                            $ModuleCaller.ExportedAliases["?<$($regex.Name)>"]
+                        } else {
+                            $true
+                        }
+
                     } else {
                         $ExecutionContext.SessionState.InvokeCommand.GetCommand("?<$($regex.Name)>",'Alias')
                     }

--- a/Use-RegEx.ps1
+++ b/Use-RegEx.ps1
@@ -171,10 +171,36 @@
     )
 
     dynamicParam {
-        # If we didn't have a regex library, create one.
-        if (-not $script:_RegexLibrary) { $script:_RegexLibrary = @{} }
-
         $myInv = $MyInvocation
+
+        # If we didn't have a regex library
+        if (-not $script:_RegexLibrary -or -not $script:_RegexLibrary.Count) {
+            # it could be because we're invoke in a place where $script: variables aren't accessible.
+            if ($myInv.MyCommand.Module) { # If that's the case, and this command is within a module
+                $script:_RegexLibrary = @{} 
+                # then we can try to look at the RegexLibraryMetadata to reconstruct out regex liberary
+                $regexMetadata = . $myInv.MyCommand.Module {$_RegexLibraryMetadata}
+                if ($regexMetadata -and $regexMetadata.getEnumerator) { # If we found metadata
+                    foreach ($kv in $regexMetadata.GetEnumerator()) { # Walk over each piece of metadata
+                        $script:_RegexLibrary[$kv.Key] = # the key format is the same for RegexLibrary.
+                            # If the value has a pattern, it's a RegEx
+                            if ($kv.Value.Pattern) 
+                            { 
+                                [Regex]::new($kv.Value.Pattern, 'IgnoreCase,IgnorePatternWhitespace','00:00:05')
+                            } 
+                            # If the path was like *.ps1, it's a RegEx Generator.
+                            elseif ($kv.Value.Path -like '*.ps1') 
+                            { 
+                                $ExecutionContext.SessionState.InvokeCommand.GetCommand($kv.Value.Path, 'ExternalScript')
+                            }
+                    }
+                }
+            }
+            if (-not $script:_RegexLibrary) {
+                $script:_RegexLibrary = @{}
+            }
+        }
+
         # Then, determine what the name of the pattern in the library would be.
         $mySafeName =
             if ('.', '&' -contains $myInv.InvocationName -and
@@ -233,6 +259,9 @@
         # If -Where or -If was provided, we need to recreate the script blocks for $_ to work.
         if ($Where) { $where = [ScriptBlock]::Create($Where) }
 
+        # In order for $_ to work correctly, 
+        # we need to recreate any script block parameters passed within dictionaries.
+        # Rather than write this three times, let's loop over each collection
         foreach ($coll in $if, $ReplaceIf, $Coerce) {
             if (-not $coll) { continue }
             foreach ($k in @($coll.Keys)) {


### PR DESCRIPTION
Fixing an issue where New-Module was being called to export all aliases, even if being called during module load.
Allowing RegExLibrary to be refreshed from $myInvocation.MyCommand.Mdoule (for script: scoping issues)

