### PR TITLE
Write RegEx Enhancements and C Regexes

### DIFF
--- a/Irregular.tests.ps1
+++ b/Irregular.tests.ps1
@@ -462,7 +462,7 @@ describe Write-Regex {
     }
 
     it 'Can Be -Atomic' {
-        Write-RegEx -Atomic -Pattern 'do', 'die' -Or | select-object -expand Pattern | should -Be '(?>do|die)'
+        Write-RegEx -Atomic -Pattern 'do', 'die' -Or | select-object -expand Pattern | should -BeLike '(?>*do*|*die*)'
     }
 
     it 'Can Be -Greedy or -Lazy (or both)' {
@@ -475,7 +475,7 @@ describe Write-Regex {
     }
 
     it 'Can -Be optional' {
-        Write-RegEx -Pattern do, die -Or -Optional | select-object -expand Pattern | should -Be '(?:do|die)?'
+        Write-RegEx -Pattern do, die -Or -Optional | select-object -expand Pattern | should -BeLike '(?:*do*|*die*)?'
     }
 
     it 'Can use Saved Expressions (with the format ?<Name>)' {

--- a/RegEx/C/IfDef.regex.source.ps1
+++ b/RegEx/C/IfDef.regex.source.ps1
@@ -1,0 +1,12 @@
+﻿$myName = ($MyInvocation.MyCommand.ScriptBlock.File | Split-Path -Leaf) -replace '\.source', '' -replace '\.ps1', '.txt'
+$myRoot = $MyInvocation.MyCommand.ScriptBlock.File | Split-Path
+Write-RegEx -Description @'
+Matches C/C++ #if/#ifdef/#ifndef .. #endif
+'@ -Pattern "\#\s{0,}" -Comment " As long as we're not after comments, Match the #, followed by" -Modifier Multiline -NotAfter '//' |
+    Write-RegEx -Name If -Pattern 'if[^\s]+' -Comment "Match <If> (and the rest of the word)" |
+    Write-RegEx -Pattern '.?$' -Name 'Condition' -Comment  "the <Condition> is anything until the end of the line" |
+    Write-RegEx -Until (
+        Write-RegEx -LiteralCharacter '#' | Write-RegEx -Pattern endif
+    ) |
+    Write-RegEx -LiteralCharacter '#' | Write-RegEx -Pattern endif |
+    Set-Content -Path (Join-Path $myRoot $myName) -Encoding UTF8 -PassThru

--- a/RegEx/C/IfDef.regex.source.ps1
+++ b/RegEx/C/IfDef.regex.source.ps1
@@ -1,12 +1,19 @@
 ﻿$myName = ($MyInvocation.MyCommand.ScriptBlock.File | Split-Path -Leaf) -replace '\.source', '' -replace '\.ps1', '.txt'
 $myRoot = $MyInvocation.MyCommand.ScriptBlock.File | Split-Path
-Write-RegEx -Description @'
+$r =Write-RegEx -Description @'
 Matches C/C++ #if/#ifdef/#ifndef .. #endif
-'@ -Pattern "\#\s{0,}" -Comment " As long as we're not after comments, Match the #, followed by" -Modifier Multiline -NotAfter '//' |
-    Write-RegEx -Name If -Pattern 'if[^\s]+' -Comment "Match <If> (and the rest of the word)" |
-    Write-RegEx -Pattern '.?$' -Name 'Condition' -Comment  "the <Condition> is anything until the end of the line" |
-    Write-RegEx -Until (
-        Write-RegEx -LiteralCharacter '#' | Write-RegEx -Pattern endif
-    ) |
-    Write-RegEx -LiteralCharacter '#' | Write-RegEx -Pattern endif |
-    Set-Content -Path (Join-Path $myRoot $myName) -Encoding UTF8 -PassThru
+'@ -Pattern "\#\s{0,}" -Comment " As long as we're not after comments, Match the #, followed by" -Modifier Multiline -NotAfter '//' -Before 'if' |
+    Write-RegEx -Name If -Pattern 'if[^\s]+' -Comment "Match <If> (and the rest of the word)" |     
+    Write-RegEx -Pattern '.+?$' -Name 'Condition' -Comment  "the <Condition> is anything until the end of the line" |    
+    Write-RegEx -Atomic -Or @(
+        Write-RegEx -LiteralCharacter '#' -Not -Repeat -Comment "Any non-preprocessor character matches, and doesn't change the balance"
+        Write-RegEx -NotAfter '//' -Pattern '\#if.+?$' |
+            Write-RegEx -Name 'Depth' -Comment "An #if Increases the <Depth>"
+        Write-RegEx -NotAfter '//' -Pattern '\#endif' |
+            Write-RegEx -Name '-Depth' -Comment "An EndIf Decreases the Depth"
+        Write-RegEx -LiteralCharacter '#' -Comment 'Match any remaining #'
+    ) -Description "Now things get tricky.  Because ifdefs can nest, we need a balancing group" |
+    Write-RegEx -Greedy | 
+    Write-Regex -If 'Depth' -Then '?!' -Comment "Match until EndIf is balanced" |
+    Write-RegEx -NotAfter '//' -Pattern '\#endif' -Comment "Match the endIf" |
+    Set-Content -Path (Join-Path $myRoot $myName) -Encoding UTF8 -PassThru 

--- a/RegEx/C/IfDef.regex.txt
+++ b/RegEx/C/IfDef.regex.txt
@@ -1,0 +1,5 @@
+﻿# Matches C/C++ #if/#ifdef/#ifndef .. #endif
+(?m)(?<!//)\#\s{0,} #  As long as we're not after comments, Match the , followed by
+(?<If>if[^\s]+)   # Match <If> (and the rest of the word)
+(?<Condition>.?$) # the <Condition> is anything until the end of the line
+(?:.|\s){0,}?(?=\z|\#endif)\#endif

--- a/RegEx/C/IfDef.regex.txt
+++ b/RegEx/C/IfDef.regex.txt
@@ -1,5 +1,16 @@
 ﻿# Matches C/C++ #if/#ifdef/#ifndef .. #endif
-(?m)(?<!//)\#\s{0,} #  As long as we're not after comments, Match the , followed by
-(?<If>if[^\s]+)   # Match <If> (and the rest of the word)
-(?<Condition>.?$) # the <Condition> is anything until the end of the line
-(?:.|\s){0,}?(?=\z|\#endif)\#endif
+(?m)(?<!//)\#\s{0,}(?=if)   #  As long as we're not after comments, Match the , followed by
+(?<If>if[^\s]+)             # Match <If> (and the rest of the word)
+(?<Condition>.+?$)          # the <Condition> is anything until the end of the line
+# Now things get tricky.  Because ifdefs can nest, we need a balancing group
+(?>
+  [^\#]+                    # Any non-preprocessor character matches, and doesn't change the balance
+  |
+  (?<!//)\#if.+?$(?<Depth>) # An if Increases the <Depth>
+  |
+  (?<!//)\#endif(?<-Depth>) # An EndIf Decreases the Depth
+  |
+  \#                        # Match any remaining 
+)*(?(Depth)(?!))            # Match Until EndIf is balanced
+(?<!//)\#endif              # Match the endIf
+

--- a/Write-RegEx.ps1
+++ b/Write-RegEx.ps1
@@ -445,10 +445,8 @@
                     if ($escapeSequence -ne ($firstBetween * 2)) {
                         $pattern = "(?:.|\s)*?(?=\z|${escapePattern}${secondBetween})"
                     } else {
-
                         $pattern = "(?:$escapeSequence|[^$firstBetween])*(?=\z|$secondBetween)"
                     }
-
                 }
                 $theOC++
             }
@@ -606,9 +604,9 @@
 
             if ($If -and $Then) { # If they passed us a coniditional, embed it
                 if ($Else) {
-                    "(?($if)(?:$($then -join ''))|(?:$($else -join '')))"
+                    "(?($if)($($then -join ''))|($($else -join '')))"
                 } else {
-                    "(?($if)(?:$($then -join '')))"
+                    "(?($if)($($then -join '')))"
                 }
             }
 

--- a/Write-RegEx.ps1
+++ b/Write-RegEx.ps1
@@ -462,7 +462,8 @@
             }
 
             if ($Atomic) {
-                "(?>"; $theOC++
+                $theOC++
+                "(?>" + [Environment]::NewLine + (' ' * $theOc * 2)
             }
 
             if ($NoCapture) {
@@ -549,10 +550,11 @@
                     }
 
                 if ($Or -and $Pattern.Length -gt 1) { # (join multiples with | if -Of is passed)
+                    $joinWith = (' ' * $theOc * 2) + '|' + [Environment]::NewLine + (' ' * $theOc * 2)
                     if ($atomic) {
-                        $pattern -join '|'
+                        $pattern -join $joinWith
                     } else {
-                        "(?:$($Pattern -join '|'))"
+                        "(?:$($Pattern -join $joinWith))"
                     }
                 }
                 elseif ($Not) { "\A((?!($($Pattern -join ''))).)*\Z" } # (create an antipattern if -Not is passed)
@@ -681,15 +683,13 @@
 
         if (-not $Denormalized) {
             $regexLines = $regex -split '(?>\r\n|\n)'
+            $findComment = [Regex]::new('(?<!\\)\#')
             $commentIndeces =
                 foreach ($l in $regexLines) {
-                    if ($l.Contains('#')) {
-                        $commentIndex = $l.IndexOf('#')
-                        if ($commentIndex -eq 0) {
-                            # Not important for normalization
-                        } elseif ($l[$commentIndex - 1] -ne '\') {
-                            # As long as the comment is not escaped
-                            $commentIndex
+                    $matched = @($findComment.Matches($l))
+                    if ($matched) {                        
+                        if ($matched[0].Index -gt 0) {
+                            $matched[0].Index
                         }
                     }
                 }
@@ -700,19 +700,17 @@
 
             $regex =
                 @(foreach ($l in $regexLines) {
-                    if ($l.Contains('#')) {
-                        $commentIndex = $l.IndexOf('#')
+                    $matched = @($findComment.Matches($l))
+                    if ($matched) {
+                        $commentIndex = $matched[0].Index                        
                         if ($commentIndex -eq 0) {
                             # Not important for normalization
                             $l
-                        } elseif ($l[$commentIndex - 1] -ne '\') {
+                        } else {
                             # As long as the comment is not escaped
                             $l.Substring(0, $commentIndex) + $(
                                 ' ' * ($max - $commentIndex)
                             ) + $l.Substring($commentIndex)
-
-                        } else {
-                            $l
                         }
                     } else {
                         $l


### PR DESCRIPTION
Adding ?<C_IfDef> ( #46  ) 
Fixing Write-RegEx -If/-Then issue ( #48 )
Indenting -Atomic expresssions and -Or ( #49 )
Fixing issue when normalizing lines without non-comment pound signs ( #50 )

