### PR TITLE
Irregular music

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
   * ?<ANSI_Note> (Match ANSI VT520 note sequences) (Fixes #127) 
 * Updated Patterns:
   * ?<FFMpeg_Progress>: Supporting duplicated / dropped frames (Fixes #128)
-  * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #127)
+  * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #126)
 ---
 
 ## 0.7.0:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-﻿## 0.7.0:
+﻿## 0.7.1:
+* New Pattern:
+  * ?<ANSI_Note> (Match ANSI VT520 note sequences) (Fixes #127) 
+* Updated Patterns:
+  * ?<FFMpeg_Progress>: Supporting duplicated / dropped frames (Fixes #128)
+  * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #127)
+---
+
+## 0.7.0:
 * New Patterns:
   * ANSI
     * ?<ANSI_Code>  (Fixes #123)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿## 0.7.1:
 * New Pattern:
-  * ?<ANSI_Note> (Match ANSI VT520 note sequences) (Fixes #127) 
+  * ?<ANSI_Note> (Match ANSI VT520 / DECPS note sequences) (Fixes #127) 
 * Updated Patterns:
   * ?<FFMpeg_Progress>: Supporting duplicated / dropped frames (Fixes #128)
   * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #126)

--- a/Irregular.format.ps1xml
+++ b/Irregular.format.ps1xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-16"?>
-<!-- Generated with EZOut 1.9.0: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
+<!-- Generated with EZOut 1.9.2: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
 <Configuration>
   <ViewDefinitions>
     <View>

--- a/Irregular.psd1
+++ b/Irregular.psd1
@@ -19,7 +19,7 @@
   * ?<ANSI_Note> (Match ANSI VT520 note sequences) (Fixes #127) 
 * Updated Patterns:
   * ?<FFMpeg_Progress>: Supporting duplicated / dropped frames (Fixes #128)
-  * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #127)
+  * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #126)
 ---
 ## 0.7.0:
 * New Patterns:

--- a/Irregular.psd1
+++ b/Irregular.psd1
@@ -16,7 +16,7 @@
             ReleaseNotes = @'
 ## 0.7.1:
 * New Pattern:
-  * ?<ANSI_Note> (Match ANSI VT520 note sequences) (Fixes #127) 
+  * ?<ANSI_Note> (Match ANSI VT520 / DECPS note sequences) (Fixes #127) 
 * Updated Patterns:
   * ?<FFMpeg_Progress>: Supporting duplicated / dropped frames (Fixes #128)
   * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #126)

--- a/Irregular.psd1
+++ b/Irregular.psd1
@@ -1,5 +1,5 @@
 ﻿@{
-    ModuleVersion = '0.7.0'
+    ModuleVersion = '0.7.1'
     RootModule = 'Irregular.psm1'
     Description = 'Regular Expressions made Strangely Simple'
     FormatsToProcess = 'Irregular.format.ps1xml'
@@ -14,6 +14,13 @@
             LicenseURI = 'https://github.com/StartAutomating/Irregular/blob/master/LICENSE'
             IconURI    = 'https://github.com/StartAutomating/Irregular/blob/master/Assets/Irregular_600_Square.png'        
             ReleaseNotes = @'
+## 0.7.1:
+* New Pattern:
+  * ?<ANSI_Note> (Match ANSI VT520 note sequences) (Fixes #127) 
+* Updated Patterns:
+  * ?<FFMpeg_Progress>: Supporting duplicated / dropped frames (Fixes #128)
+  * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #127)
+---
 ## 0.7.0:
 * New Patterns:
   * ANSI

--- a/Irregular.types.ps1xml
+++ b/Irregular.types.ps1xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-16"?>
-<!-- Generated with EZOut 1.9.0: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
+<!-- Generated with EZOut 1.9.2: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
 <Types>
   <Type>
     <Name>Irregular.Match.Extract</Name>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <h2>Regular Expressions made Strangely Simple</h2>
 <h3>A PowerShell module that helps you understand, use, and build Regular Expressions.</h3>
 <h4>
-<a href='https://github.com/StartAutomating/Irregular/releases/tag/v0.7.0'>v 0.7.0 </a>
+<a href='https://github.com/StartAutomating/Irregular/releases/tag/v0.7.1'>v 0.7.1 </a>
 </h4>
 <a href='https://www.powershellgallery.com/packages/Irregular/'>
 <img src='https://img.shields.io/powershellgallery/dt/Irregular' />
@@ -32,7 +32,7 @@ Once you understand some basics of that syntax, regular expressions become a lot
 3. A Regex can have comments! ( # Like this in .NET  ( or like (?#this comment) in ECMAScript ) ).
 4. You don't have to do it all in one expression! 
 
-Irregular comes with 118 useful [named expressions](SavedPatterns.md), and lets you create more.
+Irregular comes with 119 useful [named expressions](SavedPatterns.md), and lets you create more.
 
 To see the expressions that ship with Irregular, run:
 

--- a/RegEx/ANSI/Note.regex.source.ps1
+++ b/RegEx/ANSI/Note.regex.source.ps1
@@ -1,0 +1,50 @@
+$myName = ($MyInvocation.MyCommand.ScriptBlock.File | Split-Path -Leaf) -replace '\.source', '' -replace '\.ps1', '.txt'
+$myRoot = $MyInvocation.MyCommand.ScriptBlock.File | Split-Path
+
+New-RegEx -Description "Matches an ANSI VT520 Note" |
+New-RegEx -CharacterClass Escape -Comment 'An Escape' |
+New-RegEx -LiteralCharacter '[' -Comment 'Followed by a bracket' |
+New-RegEx -Name Volume -Atomic -Or -Pattern @(
+    New-RegEx -Name VolumeOff -Pattern 0 -Comment "0 is no volume"
+    New-RegEx -Name VolumeLow -Pattern '[1-3]' -Comment "1-3 is low volume"
+    New-RegEx -Name VolumeHigh -Pattern '[4-7]' -Comment "4-7 is high volume"
+) |
+New-RegEx -LiteralCharacter ';' -Comment 'A semicolon separated the volume from the duration' |
+New-RegEx -Name Duration -Description "Duration is measured in 1/32 of a second" -Pattern '\d+' | 
+New-RegEx -LiteralCharacter ';' -Comment 'A semicolon separates the duration from the note' |
+New-RegEx -Name Notes -Description "One or more notes will follow" -Pattern (
+    New-RegEx -NoCapture -Min 0 (
+        New-RegEx -Atomic -Or @(
+            New-RegEx -Pattern 25 -Name 'C7'      -Comment '25 is C in the 7th octave (MIDI 96)'
+            New-RegEx -Pattern 24 -Name 'B6'      -Comment '24 is B in the 6th octave (MIDI 95)'
+            New-RegEx -Pattern 23 -Name 'ASharp6' -Comment '23 is A Sharp in the 6th octave (MIDI 94)'
+            New-RegEx -Pattern 22 -Name 'A6'      -Comment '22 is A in the 6th octave (MIDI 93)'
+            New-RegEx -Pattern 21 -Name 'GSharp6' -Comment '21 is G Sharp in the 6th octave (MIDI 92)'
+            New-RegEx -Pattern 20 -Name 'G6'      -Comment '20 is G in the 6th octave (MIDI 91)'
+            New-RegEx -Pattern 19 -Name 'FSharp6' -Comment '19 is F Sharp in the 6th octave (MIDI 90)'
+            New-RegEx -Pattern 18 -Name 'F6'      -Comment '18 is F in the 6th octave (MIDI 89)'
+            New-RegEx -Pattern 17 -Name 'E6'      -Comment '17 is E in the 6th octave (MIDI 88)'
+            New-RegEx -Pattern 16 -Name 'DSharp6' -Comment '16 is D Sharp in the 6th octave (MIDI 87)'
+            New-RegEx -Pattern 15 -Name 'D6'      -Comment '15 is D in the 6th octave (MIDI 86)'
+            New-RegEx -Pattern 14 -Name 'CSharp6' -Comment '14 is C Sharp in the 6th octave (MIDI 85)'
+            New-RegEx -Pattern 13 -Name 'C6'      -Comment '13 is C in the 6th octave (MIDI 84)'
+            New-RegEx -Pattern 12 -Name 'B5'      -Comment "12 is B in the 5th octave (MIDI 83)"
+            New-RegEx -Pattern 11 -Name 'ASharp5' -Comment "11 is A Sharp in the 5th octave (MIDI 82)"
+            New-RegEx -Pattern 10 -Name 'A5'      -Comment "10 is A in the 5th octave (MIDI 81)"
+            New-RegEx -Pattern 9  -Name 'GSharp5' -Comment "9 is G Sharp in the 5th octave (MIDI 80)"
+            New-RegEx -Pattern 8  -Name 'G5'      -Comment "8 is G in the 5th octave (MIDI 79)"
+            New-RegEx -Pattern 7  -Name 'FSharp5' -Comment "7 is F Sharp in the 5th octave (MIDI 78)" 
+            New-RegEx -Pattern 6  -Name 'F5'      -Comment "6 is F in the 5th octave (MIDI 77)"
+            New-RegEx -Pattern 5  -Name 'E5'      -Comment "5 is E in the 5th octave (MIDI 76)"
+            New-RegEx -Pattern 4  -Name 'DSharp5' -Comment "4 is D Sharp in the 5th octave (MIDI 75)"
+            New-RegEx -Pattern 3  -Name 'D5'      -Comment "3 is D in the 5th octave (MIDI 74)"
+            New-RegEx -Pattern 2  -Name 'CSharp5' -Comment "2 is C Sharp in the 5th octave (MIDI 73)"
+            New-RegEx -Pattern 1  -Name 'C5'      -Comment "1 is C in the 5th octave (MIDI 72)"
+            New-RegEx -Pattern 0  -Name 'Rest'    -Comment "0 is a rest"
+        ) |
+        New-RegEx -LiteralCharacter ';' -Optional    
+    )
+) |
+New-RegEx -Pattern ',~' -Comment "A command and a tilda end the sequence" |
+Set-Content -Path (Join-Path $myRoot $myName)
+

--- a/RegEx/ANSI/Note.regex.txt
+++ b/RegEx/ANSI/Note.regex.txt
@@ -1,0 +1,65 @@
+# Matches an ANSI VT520 Note
+\e                          # An Escape
+\[                          # Followed by a bracket
+(?>
+  (?<Volume>(?<VolumeOff>0) # 0 is no volume
+    |
+    (?<VolumeLow>[1-3])     # 1-3 is low volume
+    |
+    (?<VolumeHigh>[4-7])    # 4-7 is high volume
+))\;                        # A semicolon separated the volume from the duration
+# Duration is measured in 1/32 of a second
+(?<Duration>\d+)\;          # A semicolon separates the duration from the note
+# One or more notes will follow
+(?<Notes>(?:(?>
+  (?<C5>25)                 # 25 is C in the 6th octave (MIDI 96)
+  |
+  (?<B5>24)                 # 24 is B in the 5th octave (MIDI 95)
+  |
+  (?<ASharp5>23)            # 23 is A Sharp in the 5th octave (MIDI 94)
+  |
+  (?<A5>22)                 # 22 is A in the 5th octave (MIDI 93)
+  |
+  (?<GSharp5>21)            # 21 is G Sharp in the 5th octave (MIDI 92)
+  |
+  (?<G5>20)                 # 20 is G in the 5th octave (MIDI 91)
+  |
+  (?<FSharp5>19)            # 19 is F Sharp in the 5th octave (MIDI 90)
+  |
+  (?<F5>18)                 # 18 is F in the 5th octave (MIDI 89)
+  |
+  (?<E5>17)                 # 17 is F in the 5th octave (MIDI 88)
+  |
+  (?<DSharp5>16)            # 16 is D Sharp in the 5th octave (MIDI 87)
+  |
+  (?<D5>15)                 # 15 is D in the 5th octave (MIDI 86)
+  |
+  (?<CSharp5>14)            # 14 is C Sharp in the 5th octave (MIDI 85)
+  |
+  (?<C5>13)                 # 13 is C in the 5th octave (MIDI 84)
+  |
+  (?<B4>12)                 # 12 is B in the 4th octave (MIDI 83)
+  |
+  (?<ASharp4>11)            # 11 is A Sharp in the 4th octave (MIDI 82)
+  |
+  (?<A4>10)                 # 10 is A in the 4th octave (MIDI 81)
+  |
+  (?<GSharp4>9)             # 9 is G Sharp in the 4th octave (MIDI 80)
+  |
+  (?<G4>8)                  # 8 is G in the 4th octave (MIDI 79)
+  |
+  (?<FSharp4>7)             # 7 is F Sharp in the 4th octave (MIDI 78)
+  |
+  (?<F4>6)                  # 6 is F in the 4th octave (MIDI 77)
+  |
+  (?<E4>5)                  # 5 is E in the 4th octave (MIDI 76)
+  |
+  (?<DSharp4>4)             # 4 is D Sharp in the 4th octave (MIDI 75)
+  |
+  (?<D4>3)                  # 3 is D in the 4th octave (MIDI 74)
+  |
+  (?<CSharp4>2)             # 2 is C Sharp in the 4th octave (MIDI 73)
+  |
+  (?<C4>1)                  # 1 is C in the 4th octave (MIDI 72)
+)\;?){0,}),~                # A command and a tilda end the sequence
+

--- a/RegEx/ANSI/README.md
+++ b/RegEx/ANSI/README.md
@@ -11,5 +11,6 @@ Note:  Using these regular expressions in the terminal may result in awkward out
 |[?<ANSI_Code>](Code.regex.txt)                |Matches an ANSI escape code     |False      |
 |[?<ANSI_Color>](Color.regex.txt)              |Matches an ANSI color           |False      |
 |[?<ANSI_DefaultColor>](DefaultColor.regex.txt)|Matches an ANSI 24-bit color    |False      |
+|[?<ANSI_Note>](Note.regex.txt)                |Matches an ANSI VT520 Note      |False      |
 
 

--- a/RegEx/Code/BuildVersion.regex.txt
+++ b/RegEx/Code/BuildVersion.regex.txt
@@ -1,6 +1,7 @@
 ﻿# Matches a build version
-(?<Major>\d+)
-\.
-(?<Minor>\d+)
-(?:\.(?<Build>\d+))?
-(?:\.(?<Revision>\d+))?
+(?!\p{P})               # Do not match if preceeded by punctuation
+(?<Major>\d+)           # Match a major version
+\.                      # followed by a period
+(?<Minor>\d+)           # followed by a minor version
+(?:\.(?<Build>\d+))?    # followed by an optional build number
+(?:\.(?<Revision>\d+))? # followed by an optional build revision.

--- a/RegEx/FFmpeg/Progress.regex.source.ps1
+++ b/RegEx/FFmpeg/Progress.regex.source.ps1
@@ -1,35 +1,47 @@
 ﻿$myName = ($MyInvocation.MyCommand.ScriptBlock.File | Split-Path -Leaf) -replace '\.source', '' -replace '\.ps1', '.txt'
 $myRoot = $MyInvocation.MyCommand.ScriptBlock.File | Split-Path
-Write-RegEx -Description @'
+New-RegEx -Description @'
 Matches Progress Lines in FFMpeg output
 '@  -StartAnchor LineStart -Pattern "frame=" -Comment "frame=" |
-    Write-RegEx -CharacterClass Whitespace -Min 0 |
-    Write-RegEx -Name FrameNumber -CharacterClass Digit -Repeat |
-    Write-RegEx -CharacterClass Whitespace -Min 0 -Comment "Followed by the Frame Number" |
-    Write-RegEx -Pattern fps= -Comment "fps="|
-    Write-RegEx -CharacterClass Whitespace -Min 0 |
-    Write-RegEx -Name FramesPerSecond (
-        Write-RegEx -CharacterClass Digit -LiteralCharacter '.' -Repeat
+    New-RegEx -CharacterClass Whitespace -Min 0 |
+    New-RegEx -Name FrameNumber -CharacterClass Digit -Repeat |
+    New-RegEx -CharacterClass Whitespace -Min 0 -Comment "Followed by the Frame Number" |
+    New-RegEx -Pattern fps= -Comment "fps="|
+    New-RegEx -CharacterClass Whitespace -Min 0 |
+    New-RegEx -Name FramesPerSecond (
+        New-RegEx -CharacterClass Digit -LiteralCharacter '.' -Repeat
     ) |
-    Write-RegEx -CharacterClass Whitespace -Repeat -Comment "Followed by Frames Per Second"  |
-    Write-RegEx -Pattern q= -Comment "q=" |    
-    Write-RegEx -Name QuanitizerScale -CharacterClass Digit -LiteralCharacter .  -Repeat |
-    Write-RegEx -CharacterClass Whitespace -Repeat -Comment "Followed by the Quanitizer Scale"   |    
-    Write-RegEx -Pattern L?size= -Comment "size=" |
-    Write-RegEx -CharacterClass Whitespace -Repeat |
-    Write-RegEx -Name Size -Pattern "\d{1,}\wB" |
-    Write-RegEx -CharacterClass Whitespace -Repeat -Comment "Followed by the Size"  |
-    Write-RegEx -Pattern time= -Comment "time=" |   
-    Write-RegEx -Name Time -Pattern "[\d\:\.]+" |
-    Write-RegEx -CharacterClass Whitespace -Min 0 -Comment "Followed by the Time" |
-    Write-RegEx -Pattern bitrate= -Comment "bitrate=" |
-    Write-RegEx -CharacterClass Whitespace -Min 0 |
-    Write-RegEx -Name Bitrate -Pattern "[\d\.exN/A]+" |
-    Write-RegEx -Pattern 'kbits/s' |     
-    Write-RegEx -CharacterClass Whitespace -Min 0 -Comment "Followed by the Bitrate" |
-    Write-RegEx -Pattern speed= -Comment "speed=" |
-    Write-RegEx -CharacterClass Whitespace -Min 0 |
-    Write-RegEx -Name Speed -Pattern "[\d\.N/A+]+" |
-    Write-RegEx -Pattern 'x' |     
-    Write-RegEx -CharacterClass Whitespace -Min 0 -Comment "Followed by the Speed" |#>
+    New-RegEx -CharacterClass Whitespace -Repeat -Comment "Followed by Frames Per Second"  |
+    New-RegEx -Pattern q= -Comment "q=" |    
+    New-RegEx -Name QuanitizerScale -Pattern "[\d\.N/A+]+" |
+    New-RegEx -CharacterClass Whitespace -Repeat -Comment "Followed by the Quanitizer Scale"   |    
+    New-RegEx -Pattern L?size= -Comment "size=" |
+    New-RegEx -CharacterClass Whitespace -Repeat |
+    New-RegEx -Name Size -Pattern "\d{1,}\wB" |
+    New-RegEx -CharacterClass Whitespace -Repeat -Comment "Followed by the Size"  |
+    New-RegEx -Pattern time= -Comment "time=" |   
+    New-RegEx -Name Time -Pattern "[\d\:\.]+" |
+    New-RegEx -CharacterClass Whitespace -Min 0 -Comment "Followed by the Time" |
+    New-RegEx -Pattern bitrate= -Comment "bitrate=" |
+    New-RegEx -CharacterClass Whitespace -Min 0 |
+    New-RegEx -Name Bitrate -Pattern "[\d\.exN/A]+" |
+    New-RegEx -Pattern 'kbits/s' |
+    New-RegEx -Atomic -Min 0 -Pattern (
+        New-RegEx -CharacterClass Whitespace -Min 0 -Comment "Followed by optional duplicated frame count" |
+            New-RegEx -Pattern dup= -Comment "dup=" |
+            New-RegEx -CharacterClass Whitespace -Min 0 |
+            New-RegEx -Name Duplicated -Pattern "\d+"
+    ) |
+    New-RegEx -Atomic -Min 0 -Pattern (
+        New-RegEx -CharacterClass Whitespace -Min 0 -Comment "Followed by optional dropped frame count" |
+            New-RegEx -Pattern drop= -Comment "drop=" |
+            New-RegEx -CharacterClass Whitespace -Min 0 |
+            New-RegEx -Name Dropped -Pattern "\d+"
+    ) |
+    New-RegEx -CharacterClass Whitespace -Min 0 -Comment "Followed by the Bitrate" |
+    New-RegEx -Pattern speed= -Comment "speed=" |
+    New-RegEx -CharacterClass Whitespace -Min 0 |
+    New-RegEx -Name Speed -Pattern "[\d\.N/A+]+" |
+    New-RegEx -Pattern 'x' |     
+    New-RegEx -CharacterClass Whitespace -Min 0 -Comment "Followed by the Speed" |#>
     Set-Content -Path (Join-Path $myRoot $myName) -Encoding UTF8 -PassThru

--- a/RegEx/FFmpeg/Progress.regex.txt
+++ b/RegEx/FFmpeg/Progress.regex.txt
@@ -1,16 +1,22 @@
-﻿# Matches Progress Lines in FFMpeg output
-^frame=                                     # frame=
-\s{0,}(?<FrameNumber>\d+)\s{0,}             # Followed by the Frame Number
-fps=                                        # fps=
-\s{0,}(?<FramesPerSecond>[\d\.]+)\s+        # Followed by Frames Per Second
-q=                                          # q=
-(?<QuanitizerScale>[\d\.]+)\s+              # Followed by the Quanitizer Scale
-L?size=                                     # size=
-\s+(?<Size>\d{1,}\wB)\s+                    # Followed by the Size
-time=                                       # time=
-(?<Time>[\d\:\.]+)\s{0,}                    # Followed by the Time
-bitrate=                                    # bitrate=
-\s{0,}(?<Bitrate>[\d\.exN/A]+)kbits/s\s{0,} # Followed by the Bitrate
-speed=                                      # speed=
-\s{0,}(?<Speed>[\d\.N/A+]+)x\s{0,}          # Followed by the Speed
+# Matches Progress Lines in FFMpeg output
+^frame=                              # frame=
+\s{0,}(?<FrameNumber>\d+)\s{0,}      # Followed by the Frame Number
+fps=                                 # fps=
+\s{0,}(?<FramesPerSecond>[\d\.]+)\s+ # Followed by Frames Per Second
+q=                                   # q=
+(?<QuanitizerScale>[\d\.]+)\s+       # Followed by the Quanitizer Scale
+L?size=                              # size=
+\s+(?<Size>\d{1,}\wB)\s+             # Followed by the Size
+time=                                # time=
+(?<Time>[\d\:\.]+)\s{0,}             # Followed by the Time
+bitrate=                             # bitrate=
+\s{0,}(?<Bitrate>[\d\.exN/A]+)kbits/s(?>
+  \s{0,}                             # Followed by optional duplicated frame count
+dup=                                 # dup=
+\s{0,}(?<Duplicated>\d+)){0,}(?>
+  \s{0,}                             # Followed by optional dropped frame count
+drop=                                # drop=
+\s{0,}(?<Dropped>\d+)){0,}\s{0,}     # Followed by the Bitrate
+speed=                               # speed=
+\s{0,}(?<Speed>[\d\.N/A+]+)x\s{0,}   # Followed by the Speed
 

--- a/SavedPatterns.md
+++ b/SavedPatterns.md
@@ -1,5 +1,5 @@
 ### Irregular Patterns
-Irregular includes 118 regular expressions
+Irregular includes 119 regular expressions
 |Name|Description|IsGenerator|
 |:---|:----------|:----------|
 |[ANSI_24BitColor](/RegEx/ANSI/24BitColor.regex.txt)|Matches an ANSI 24-bit color|False|
@@ -8,6 +8,7 @@ Irregular includes 118 regular expressions
 |[ANSI_Code](/RegEx/ANSI/Code.regex.txt)|Matches an ANSI escape code|False|
 |[ANSI_Color](/RegEx/ANSI/Color.regex.txt)|Matches an ANSI color|False|
 |[ANSI_DefaultColor](/RegEx/ANSI/DefaultColor.regex.txt)|Matches an ANSI 24-bit color|False|
+|[ANSI_Note](/RegEx/ANSI/Note.regex.txt)|Matches an ANSI VT520 Note|False|
 |[ArithmeticOperator](/RegEx/ArithmeticOperator.regex.txt)|Simple Arithmetic Operators|False|
 |[BalancedBrackets](/RegEx/BalancedBrackets.regex.txt)|Matches content in brackets, as long as it is balanced|False|
 |[BalancedCode](/RegEx/BalancedCode.regex.ps1)|Matches code balanced by a [, {, or (|True|

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
   * ?<ANSI_Note> (Match ANSI VT520 note sequences) (Fixes #127) 
 * Updated Patterns:
   * ?<FFMpeg_Progress>: Supporting duplicated / dropped frames (Fixes #128)
-  * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #127)
+  * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #126)
 ---
 
 ## 0.7.0:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.7.1:
 * New Pattern:
-  * ?<ANSI_Note> (Match ANSI VT520 note sequences) (Fixes #127) 
+  * ?<ANSI_Note> (Match ANSI VT520 / DECPS note sequences) (Fixes #127) 
 * Updated Patterns:
   * ?<FFMpeg_Progress>: Supporting duplicated / dropped frames (Fixes #128)
   * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #126)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.1:
+* New Pattern:
+  * ?<ANSI_Note> (Match ANSI VT520 note sequences) (Fixes #127) 
+* Updated Patterns:
+  * ?<FFMpeg_Progress>: Supporting duplicated / dropped frames (Fixes #128)
+  * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #127)
+---
+
 ## 0.7.0:
 * New Patterns:
   * ANSI

--- a/docs/Export-RegEx.md
+++ b/docs/Export-RegEx.md
@@ -135,7 +135,7 @@ If the command sets a ```[ConfirmImpact("Medium")]``` which is lower than ```$co
 ---
 ### Syntax
 ```PowerShell
-Export-RegEx [[-Name] <String[]>] [[-Path] <String>] [[-As] <String>] [[-Noun] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-RegEx [[-Name] &lt;String[]&gt;] [[-Path] &lt;String&gt;] [[-As] &lt;String&gt;] [[-Noun] &lt;String&gt;] [-WhatIf] [-Confirm] [&lt;CommonParameters&gt;]
 ```
 ---
 ### Notes

--- a/docs/Get-RegEx.md
+++ b/docs/Get-RegEx.md
@@ -36,12 +36,12 @@ Get-RegEx -Name NextWord
 @(Get-RegEx | # Gets all saved Regular Expressions as a Markdown table
     Sort-Object Name |
     ForEach-Object -Begin {
-        '|Name|Description|IsGenerator|'
-        '|:---|:----------|:----------|'
+        &#39;|Name|Description|IsGenerator|&#39;
+        &#39;|:---|:----------|:----------|&#39;
     } -Process {
-        $desc = $_.Description -replace '[\[\{\(]', '\$0'
-        $desc=  if ($desc) {$desc | ?<NewLine> -Replace '<br/>'} else  { ''}
-        "|$($_.Name)|$desc|$($_.IsGenerator)|"
+        $desc = $_.Description -replace &#39;[\[\{\(]&#39;, &#39;\$0&#39;
+        $desc=  if ($desc) {$desc | ?&lt;NewLine&gt; -Replace &#39;&lt;br/&gt;&#39;} else  { &#39;&#39;}
+        &quot;|$($_.Name)|$desc|$($_.IsGenerator)|&quot;
     }) -join [Environment]::NewLine
 ```
 
@@ -158,7 +158,7 @@ System.Management.Automation.PSObject
 ---
 ### Syntax
 ```PowerShell
-Get-RegEx [[-Name] <String[]>] [[-FilePath] <String[]>] [[-FromModule] <String[]>] [[-As] <String>] [[-Noun] <String>] [<CommonParameters>]
+Get-RegEx [[-Name] &lt;String[]&gt;] [[-FilePath] &lt;String[]&gt;] [[-FromModule] &lt;String[]&gt;] [[-As] &lt;String&gt;] [[-Noun] &lt;String&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Import-RegEx.md
+++ b/docs/Import-RegEx.md
@@ -134,7 +134,7 @@ System.Management.Automation.PSObject
 ---
 ### Syntax
 ```PowerShell
-Import-RegEx [[-FilePath] <String[]>] [[-FromModule] <String[]>] [[-Pattern] <String[]>] [[-Name] <String[]>] [-PassThru] [<CommonParameters>]
+Import-RegEx [[-FilePath] &lt;String[]&gt;] [[-FromModule] &lt;String[]&gt;] [[-Pattern] &lt;String[]&gt;] [[-Name] &lt;String[]&gt;] [-PassThru] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/New-RegEx.md
+++ b/docs/New-RegEx.md
@@ -29,12 +29,12 @@ New-RegEx -CharacterClass Digit -Repeat -Name Digits
 
 #### EXAMPLE 3
 ```PowerShell
-# A regular expression for a quoted string (with \" and `" as valid escape sequences)
-New-RegEx -Pattern '"' |
+# A regular expression for a quoted string (with \&quot; and `&quot; as valid escape sequences)
+New-RegEx -Pattern &#39;&quot;&#39; |
         New-RegEx -CharacterClass Any -Repeat -Lazy -Before (
-            New-RegEx -Pattern '"' -NotAfter '\\|`'
+            New-RegEx -Pattern &#39;&quot;&#39; -NotAfter &#39;\\|`&#39;
         ) |
-        New-RegEx -Pattern '"'
+        New-RegEx -Pattern &#39;&quot;&#39;
 ```
 
 #### EXAMPLE 4
@@ -59,9 +59,9 @@ New-RegEx -Description "Matches an Email Address" |
 #### EXAMPLE 5
 ```PowerShell
 # Writes a pattern for multiline comments
-New-RegEx -Pattern \<\# |
-    New-RegEx -Name Block -Until \#\> |
-    New-RegEx -Pattern \#\>
+New-RegEx -Pattern \&lt;\# |
+    New-RegEx -Name Block -Until \#\&gt; |
+    New-RegEx -Pattern \#\&gt;
 ```
 
 ---
@@ -1146,7 +1146,7 @@ System.Management.Automation.PSObject
 ---
 ### Syntax
 ```PowerShell
-New-RegEx [[-Pattern] <String[]>] [-Name <String>] [-CharacterClass <String[]>] [-LiteralCharacter <String[]>] [-UnicodeCharacter <Int32[]>] [-ExcludeCharacterClass <String[]>] [-ExcludeLiteralCharacter <String[]>] [-ExcludeUnicodeCharacter <Int32[]>] [-DigitMax <UInt32>] [-Backreference <String>] [-NotAfter <String>] [-NotBefore <String>] [-After <String>] [-Before <String>] [-Repeat] [-Greedy] [-Lazy] [-Min <Int32>] [-Max <Int32>] [-If <String>] [-Then <String[]>] [-Else <String[]>] [-Until <String[]>] [-Comment <String>] [-Description <String>] [-Not] [-Or] [-StartAnchor <String>] [-EndAnchor <String>] [-Modifier <String[]>] [-Optional] [-Atomic] [-NoCapture] [-PrePattern <String[]>] [-TimeOut <TimeSpan>] [-Between <String[]>] [-EscapeSequence <String>] [-Denormalized] [-Parameter <IDictionary>] [-ArgumentList <PSObject[]>] [<CommonParameters>]
+New-RegEx [[-Pattern] &lt;String[]&gt;] [-Name &lt;String&gt;] [-CharacterClass &lt;String[]&gt;] [-LiteralCharacter &lt;String[]&gt;] [-UnicodeCharacter &lt;Int32[]&gt;] [-ExcludeCharacterClass &lt;String[]&gt;] [-ExcludeLiteralCharacter &lt;String[]&gt;] [-ExcludeUnicodeCharacter &lt;Int32[]&gt;] [-DigitMax &lt;UInt32&gt;] [-Backreference &lt;String&gt;] [-NotAfter &lt;String&gt;] [-NotBefore &lt;String&gt;] [-After &lt;String&gt;] [-Before &lt;String&gt;] [-Repeat] [-Greedy] [-Lazy] [-Min &lt;Int32&gt;] [-Max &lt;Int32&gt;] [-If &lt;String&gt;] [-Then &lt;String[]&gt;] [-Else &lt;String[]&gt;] [-Until &lt;String[]&gt;] [-Comment &lt;String&gt;] [-Description &lt;String&gt;] [-Not] [-Or] [-StartAnchor &lt;String&gt;] [-EndAnchor &lt;String&gt;] [-Modifier &lt;String[]&gt;] [-Optional] [-Atomic] [-NoCapture] [-PrePattern &lt;String[]&gt;] [-TimeOut &lt;TimeSpan&gt;] [-Between &lt;String[]&gt;] [-EscapeSequence &lt;String&gt;] [-Denormalized] [-Parameter &lt;IDictionary&gt;] [-ArgumentList &lt;PSObject[]&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,3 +154,4 @@ string: 'hello'
 
 
 
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 <h2>Regular Expressions made Strangely Simple</h2>
 <h3>A PowerShell module that helps you understand, use, and build Regular Expressions.</h3>
 <h4>
-<a href='https://github.com/StartAutomating/Irregular/releases/tag/v0.7.0'>v 0.7.0 </a>
+<a href='https://github.com/StartAutomating/Irregular/releases/tag/v0.7.1'>v 0.7.1 </a>
 </h4>
 <a href='https://www.powershellgallery.com/packages/Irregular/'>
 <img src='https://img.shields.io/powershellgallery/dt/Irregular' />
@@ -32,7 +32,7 @@ Once you understand some basics of that syntax, regular expressions become a lot
 3. A Regex can have comments! ( # Like this in .NET  ( or like (?#this comment) in ECMAScript ) ).
 4. You don't have to do it all in one expression! 
 
-Irregular comes with 118 useful [named expressions](SavedPatterns.md), and lets you create more.
+Irregular comes with 119 useful [named expressions](SavedPatterns.md), and lets you create more.
 
 To see the expressions that ship with Irregular, run:
 
@@ -150,8 +150,6 @@ string: 'hello'
         }
     }
 ~~~
-
-
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,3 +153,4 @@ string: 'hello'
 
 
 
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,5 +153,3 @@ string: 'hello'
 
 
 
-
-

--- a/docs/Remove-RegEx.md
+++ b/docs/Remove-RegEx.md
@@ -66,7 +66,7 @@ System.Nullable
 ---
 ### Syntax
 ```PowerShell
-Remove-RegEx [-Name] <String[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-RegEx [-Name] &lt;String[]&gt; [-WhatIf] [-Confirm] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/SavedPatterns.md
+++ b/docs/SavedPatterns.md
@@ -1,5 +1,5 @@
 ### Irregular Patterns
-Irregular includes 118 regular expressions
+Irregular includes 119 regular expressions
 |Name|Description|IsGenerator|
 |:---|:----------|:----------|
 |[ANSI_24BitColor](/RegEx/ANSI/24BitColor.regex.txt)|Matches an ANSI 24-bit color|False|
@@ -8,6 +8,7 @@ Irregular includes 118 regular expressions
 |[ANSI_Code](/RegEx/ANSI/Code.regex.txt)|Matches an ANSI escape code|False|
 |[ANSI_Color](/RegEx/ANSI/Color.regex.txt)|Matches an ANSI color|False|
 |[ANSI_DefaultColor](/RegEx/ANSI/DefaultColor.regex.txt)|Matches an ANSI 24-bit color|False|
+|[ANSI_Note](/RegEx/ANSI/Note.regex.txt)|Matches an ANSI VT520 Note|False|
 |[ArithmeticOperator](/RegEx/ArithmeticOperator.regex.txt)|Simple Arithmetic Operators|False|
 |[BalancedBrackets](/RegEx/BalancedBrackets.regex.txt)|Matches content in brackets, as long as it is balanced|False|
 |[BalancedCode](/RegEx/BalancedCode.regex.ps1)|Matches code balanced by a [, {, or (|True|

--- a/docs/Set-RegEx.md
+++ b/docs/Set-RegEx.md
@@ -169,7 +169,7 @@ System.Nullable
 ---
 ### Syntax
 ```PowerShell
-Set-RegEx [-Pattern] <String> [[-Name] <String>] [-Description <String>] [-Path <String>] [-Temporary] [-TimeOut <TimeSpan>] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-RegEx [-Pattern] &lt;String&gt; [[-Name] &lt;String&gt;] [-Description &lt;String&gt;] [-Path &lt;String&gt;] [-Temporary] [-TimeOut &lt;TimeSpan&gt;] [-PassThru] [-WhatIf] [-Confirm] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Show-RegEx.md
+++ b/docs/Show-RegEx.md
@@ -192,7 +192,7 @@ Irregular.RegEx.Output
 ---
 ### Syntax
 ```PowerShell
-Show-RegEx [-Pattern] <String> [[-Match] <String[]>] [-Remove] [-Replace <String>] [-Transform <String>] [[-Option] {None | IgnoreCase | Multiline | ExplicitCapture | Compiled | Singleline | IgnorePatternWhitespace | RightToLeft | ECMAScript | CultureInvariant}] [-CaseSensitive] [-Timeout <TimeSpan>] [<CommonParameters>]
+Show-RegEx [-Pattern] &lt;String&gt; [[-Match] &lt;String[]&gt;] [-Remove] [-Replace &lt;String&gt;] [-Transform &lt;String&gt;] [[-Option] {None | IgnoreCase | Multiline | ExplicitCapture | Compiled | Singleline | IgnorePatternWhitespace | RightToLeft | ECMAScript | CultureInvariant}] [-CaseSensitive] [-Timeout &lt;TimeSpan&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 

--- a/docs/Use-RegEx.md
+++ b/docs/Use-RegEx.md
@@ -27,22 +27,22 @@ Use-RegEx is normally called with an alias that is the name of a saved RegEx, fo
 ### Examples
 #### EXAMPLE 1
 ```PowerShell
-"abc" | Use-RegEx -Pattern '.'
+&quot;abc&quot; | Use-RegEx -Pattern &#39;.&#39;
 ```
 
 #### EXAMPLE 2
 ```PowerShell
-# ?<TrueOrFalse> is a saved RegEx and alias to Use-RegEx
+# ?&lt;TrueOrFalse&gt; is a saved RegEx and alias to Use-RegEx
 ```
 
 #### EXAMPLE 3
 ```PowerShell
-$txt = "true or false or true or false"
-$m = $txt | ?<TrueOrFalse> -Count 1
+$txt = &quot;true or false or true or false&quot;
+$m = $txt | ?&lt;TrueOrFalse&gt; -Count 1
 do {
     $m
-    $m = $m | ?<TrueOrFalse> -Count 1 -Scan
-} while ($m) # Looping over each match until non are found.  ?<TrueOrFalse> is an alias to Use-RegEx
+    $m = $m | ?&lt;TrueOrFalse&gt; -Count 1 -Scan
+} while ($m) # Looping over each match until non are found.  ?&lt;TrueOrFalse&gt; is an alias to Use-RegEx
 ```
 
 ---
@@ -576,10 +576,10 @@ System.Management.Automation.PSObject
 ---
 ### Syntax
 ```PowerShell
-Use-RegEx [[-Match] <String[]>] [-IsMatch] [-Measure] [-Count <Int32>] [-StartAt <Int32>] [-Remove] [-Replace <String>] [-Scan] [-ReplaceIf <IDictionary>] [-ReplaceEvaluator <ScriptBlock>] [-Split] [-Until] [-IncludeMatch] [-IncludeInputObject] [-Trim] [-Extract] [-PSTypeName <String>] [-Transform <String>] [-Coerce <IDictionary>] [-Where <ScriptBlock>] [-If <IDictionary>] [-Option {None | IgnoreCase | Multiline | ExplicitCapture | Compiled | Singleline | IgnorePatternWhitespace | RightToLeft | ECMAScript | CultureInvariant}] [-RightToLeft] [-Timeout <TimeSpan>] [-CaseSensitive] [-Pattern <String>] [-Generator <ScriptBlock>] [-ExpressionParameter <IDictionary>] [-ExpressionArgumentList <PSObject[]>] [<CommonParameters>]
+Use-RegEx [[-Match] &lt;String[]&gt;] [-IsMatch] [-Measure] [-Count &lt;Int32&gt;] [-StartAt &lt;Int32&gt;] [-Remove] [-Replace &lt;String&gt;] [-Scan] [-ReplaceIf &lt;IDictionary&gt;] [-ReplaceEvaluator &lt;ScriptBlock&gt;] [-Split] [-Until] [-IncludeMatch] [-IncludeInputObject] [-Trim] [-Extract] [-PSTypeName &lt;String&gt;] [-Transform &lt;String&gt;] [-Coerce &lt;IDictionary&gt;] [-Where &lt;ScriptBlock&gt;] [-If &lt;IDictionary&gt;] [-Option {None | IgnoreCase | Multiline | ExplicitCapture | Compiled | Singleline | IgnorePatternWhitespace | RightToLeft | ECMAScript | CultureInvariant}] [-RightToLeft] [-Timeout &lt;TimeSpan&gt;] [-CaseSensitive] [-Pattern &lt;String&gt;] [-Generator &lt;ScriptBlock&gt;] [-ExpressionParameter &lt;IDictionary&gt;] [-ExpressionArgumentList &lt;PSObject[]&gt;] [&lt;CommonParameters&gt;]
 ```
 ```PowerShell
-Use-RegEx [-Match] <String[]> [-IsMatch] [-Measure] [-Count <Int32>] [-StartAt <Int32>] [-Remove] [-Replace <String>] [-Scan] [-ReplaceIf <IDictionary>] [-ReplaceEvaluator <ScriptBlock>] [-Split] [-Until] [-IncludeMatch] [-IncludeInputObject] [-Trim] [-Extract] [-PSTypeName <String>] [-Transform <String>] [-Coerce <IDictionary>] [-Where <ScriptBlock>] [-If <IDictionary>] [-Option {None | IgnoreCase | Multiline | ExplicitCapture | Compiled | Singleline | IgnorePatternWhitespace | RightToLeft | ECMAScript | CultureInvariant}] [-RightToLeft] [-Timeout <TimeSpan>] [-CaseSensitive] [-Generator <ScriptBlock>] [-ExpressionParameter <IDictionary>] [-ExpressionArgumentList <PSObject[]>] [<CommonParameters>]
+Use-RegEx [-Match] &lt;String[]&gt; [-IsMatch] [-Measure] [-Count &lt;Int32&gt;] [-StartAt &lt;Int32&gt;] [-Remove] [-Replace &lt;String&gt;] [-Scan] [-ReplaceIf &lt;IDictionary&gt;] [-ReplaceEvaluator &lt;ScriptBlock&gt;] [-Split] [-Until] [-IncludeMatch] [-IncludeInputObject] [-Trim] [-Extract] [-PSTypeName &lt;String&gt;] [-Transform &lt;String&gt;] [-Coerce &lt;IDictionary&gt;] [-Where &lt;ScriptBlock&gt;] [-If &lt;IDictionary&gt;] [-Option {None | IgnoreCase | Multiline | ExplicitCapture | Compiled | Singleline | IgnorePatternWhitespace | RightToLeft | ECMAScript | CultureInvariant}] [-RightToLeft] [-Timeout &lt;TimeSpan&gt;] [-CaseSensitive] [-Generator &lt;ScriptBlock&gt;] [-ExpressionParameter &lt;IDictionary&gt;] [-ExpressionArgumentList &lt;PSObject[]&gt;] [&lt;CommonParameters&gt;]
 ```
 ---
 


### PR DESCRIPTION
## 0.7.1:
* New Pattern:
  * ?<ANSI_Note> (Match ANSI VT520 / DECPS note sequences) (Fixes #127) 
* Updated Patterns:
  * ?<FFMpeg_Progress>: Supporting duplicated / dropped frames (Fixes #128)
  * ?<Code_BuildVersion>: No longer matching if preceeded by punctuation (Fixes #126 )
---

This means that you can match any ANSI sequence [supported in the upcoming changes to Terminal](https://github.com/microsoft/terminal/issues/8687)
