### PR TITLE
Irregular ansi fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-﻿## 0.7.2:
+﻿## 0.7.3:
+* ANSI Improvements:
+  * Fixed ?<ANSI_Style> (Fixes #143)
+  * ?<ANSI_4BitColor> now supports bright ranges (Fixes #145)
+  * ?<ANSI_8BitColor>/?<ANSI_24BitColor> now supports background colors (Fixes #144)
+  * ?<ANSI_8BitColor>/?<ANSI_24BitColor> now supports underline colors (Fixes #146)
+---
+
+## 0.7.2:
 * Lots More ANSI support:
   * ?<ANSI_Bold> (Fixes #131)
   * ?<ANSI_Blink> (Fixes #132)

--- a/Irregular.format.ps1xml
+++ b/Irregular.format.ps1xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-16"?>
-<!-- Generated with EZOut 1.9.3: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
+<!-- Generated with EZOut 1.9.4: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
 <Configuration>
   <ViewDefinitions>
     <View>

--- a/Irregular.psd1
+++ b/Irregular.psd1
@@ -1,5 +1,5 @@
 ﻿@{
-    ModuleVersion = '0.7.2'
+    ModuleVersion = '0.7.3'
     RootModule = 'Irregular.psm1'
     Description = 'Regular Expressions made Strangely Simple'
     FormatsToProcess = 'Irregular.format.ps1xml'
@@ -14,6 +14,14 @@
             LicenseURI = 'https://github.com/StartAutomating/Irregular/blob/master/LICENSE'
             IconURI    = 'https://github.com/StartAutomating/Irregular/blob/master/Assets/Irregular_600_Square.png'        
             ReleaseNotes = @'
+## 0.7.3:
+* ANSI Improvements:
+  * Fixed ?<ANSI_Style> (Fixes #143)
+  * ?<ANSI_4BitColor> now supports bright ranges (Fixes #145)
+  * ?<ANSI_8BitColor>/?<ANSI_24BitColor> now supports background colors (Fixes #144)
+  * ?<ANSI_8BitColor>/?<ANSI_24BitColor> now supports underline colors (Fixes #146)
+---
+
 ## 0.7.2:
 * Lots More ANSI support:
   * ?<ANSI_Bold> (Fixes #131)

--- a/Irregular.types.ps1xml
+++ b/Irregular.types.ps1xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-16"?>
-<!-- Generated with EZOut 1.9.3: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
+<!-- Generated with EZOut 1.9.4: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
 <Types>
   <Type>
     <Name>Irregular.Match.Extract</Name>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once you understand some basics of that syntax, regular expressions become a lot
 3. A Regex can have comments! ( # Like this in .NET  ( or like (?#this comment) in ECMAScript ) ).
 4. You don't have to do it all in one expression! 
 
-Irregular comes with 128 useful [named expressions](SavedPatterns.md), and lets you create more.
+Irregular comes with 129 useful [named expressions](SavedPatterns.md), and lets you create more.
 
 To see the expressions that ship with Irregular, run:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <h2>Regular Expressions made Strangely Simple</h2>
 <h3>A PowerShell module that helps you understand, use, and build Regular Expressions.</h3>
 <h4>
-<a href='https://github.com/StartAutomating/Irregular/releases/tag/v0.7.2'>v 0.7.2 </a>
+<a href='https://github.com/StartAutomating/Irregular/releases/tag/v0.7.3'>v 0.7.3 </a>
 </h4>
 <a href='https://www.powershellgallery.com/packages/Irregular/'>
 <img src='https://img.shields.io/powershellgallery/dt/Irregular' />

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once you understand some basics of that syntax, regular expressions become a lot
 3. A Regex can have comments! ( # Like this in .NET  ( or like (?#this comment) in ECMAScript ) ).
 4. You don't have to do it all in one expression! 
 
-Irregular comes with 129 useful [named expressions](SavedPatterns.md), and lets you create more.
+Irregular comes with 130 useful [named expressions](SavedPatterns.md), and lets you create more.
 
 To see the expressions that ship with Irregular, run:
 

--- a/RegEx/ANSI/24BitColor.regex.source.ps1
+++ b/RegEx/ANSI/24BitColor.regex.source.ps1
@@ -13,7 +13,7 @@ New-RegEx -Description "Matches an ANSI 24-bit color" -Modifier IgnoreCase -Not 
     New-RegEx -Name Color -Pattern (
         New-Regex -Name Red -Pattern '(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2})' -Comment 'Red is the first 0-255 value' |
         New-RegEx -Pattern ';' |
-        New-Regex -Name Red -Pattern '(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2})' -Comment 'Green is the second 0-255 value' |
+        New-Regex -Name Green -Pattern '(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2})' -Comment 'Green is the second 0-255 value' |
         New-RegEx -Pattern ';' |
         New-Regex -Name Blue -Pattern '(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2})' -Comment 'Blue is the third 0-255 value' |
         New-RegEx -Pattern 'm'

--- a/RegEx/ANSI/24BitColor.regex.source.ps1
+++ b/RegEx/ANSI/24BitColor.regex.source.ps1
@@ -4,7 +4,12 @@ $myRoot = $MyInvocation.MyCommand.ScriptBlock.File | Split-Path
 New-RegEx -Description "Matches an ANSI 24-bit color" -Modifier IgnoreCase -Not |
     New-RegEx -CharacterClass Escape -Comment 'An Escape' |
     New-RegEx -LiteralCharacter '[' -Comment 'Followed by a bracket' |
-    New-RegEx -Pattern '38;2;' |
+    New-RegEx -Atomic -Or @(
+        New-RegEx -Pattern '38' -Name IsForegroundColor
+        New-RegEx -Pattern '48' -Name IsBackgroundColor
+        New-RegEx -Pattern '58' -Name IsUnderlineColor
+    ) |
+    New-RegEx -Pattern ';2;' |
     New-RegEx -Name Color -Pattern (
         New-Regex -Name Red -Pattern '(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2})' -Comment 'Red is the first 0-255 value' |
         New-RegEx -Pattern ';' |

--- a/RegEx/ANSI/24BitColor.regex.txt
+++ b/RegEx/ANSI/24BitColor.regex.txt
@@ -1,10 +1,10 @@
 # Matches an ANSI 24-bit color
-(?-i)\e                                                                               # An Escape
-\[                                                                                    # Followed by a bracket
+(?-i)\e                                                                                # An Escape
+\[                                                                                     # Followed by a bracket
 (?>
   (?<IsForegroundColor>38)  |
   (?<IsBackgroundColor>48)  |
-  (?<IsUnderlineColor>58));2;(?<Color>(?<Red>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))   # Red is the first 0-255 value
-;(?<Red>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                                        # Green is the second 0-255 value
-;(?<Blue>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                                       # Blue is the third 0-255 value
+  (?<IsUnderlineColor>58));2;(?<Color>(?<Red>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))    # Red is the first 0-255 value
+;(?<Green>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                                       # Green is the second 0-255 value
+;(?<Blue>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                                        # Blue is the third 0-255 value
 m)

--- a/RegEx/ANSI/24BitColor.regex.txt
+++ b/RegEx/ANSI/24BitColor.regex.txt
@@ -1,7 +1,10 @@
 # Matches an ANSI 24-bit color
-(?-i)\e                                                       # An Escape
-\[                                                            # Followed by a bracket
-38;2;(?<Color>(?<Red>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))   # Red is the first 0-255 value
-;(?<Red>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                # Green is the second 0-255 value
-;(?<Blue>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))               # Blue is the third 0-255 value
+(?-i)\e                                                                               # An Escape
+\[                                                                                    # Followed by a bracket
+(?>
+  (?<IsForegroundColor>38)  |
+  (?<IsBackgroundColor>48)  |
+  (?<IsUnderlineColor>58));2;(?<Color>(?<Red>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))   # Red is the first 0-255 value
+;(?<Red>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                                        # Green is the second 0-255 value
+;(?<Blue>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                                       # Blue is the third 0-255 value
 m)

--- a/RegEx/ANSI/4BitColor.regex.source.ps1
+++ b/RegEx/ANSI/4BitColor.regex.source.ps1
@@ -5,12 +5,25 @@ New-RegEx -Description "Matches an ANSI 3 or 4-bit color" |
     New-RegEx -CharacterClass Escape -Comment 'An Escape' |
     New-RegEx -LiteralCharacter '[' -Comment 'Followed by a bracket' |
     New-RegEx -Pattern (
-        New-RegEx -Pattern 1 -Optional -Name IsBright |
-        New-RegEx -LiteralCharacter ';' -Optional |
-        New-RegEx -Pattern '3[0-7]' -Name ForegroundColor -Optional |
-        New-RegEx -If ForegroundColor -Then 'm' -Else (
-            New-RegEx -Pattern '4[0-7]' -Name BackgroundColor | 
-                New-RegEx -Pattern 'm' -Modifier IgnoreCase -Not
-        ) 
-    ) -Name Color |    
+        
+        New-RegEx -Atomic -Or @(
+            New-RegEx -Pattern 1 -Optional -Name IsBright |
+                New-RegEx -LiteralCharacter ';' -Min 0 -Max 1 |    
+                New-RegEx -Pattern '3' -Name IsForegroundColor
+            
+            New-RegEx -Name IsBright (
+                New-RegEx -Pattern '9' -Name IsForegroundColor
+            )
+            
+            New-RegEx -Pattern 1 -Optional -Name IsBright |
+                New-RegEx -LiteralCharacter ';' -Min 0 -Max 1 |
+                New-RegEx -Pattern '4' -Name IsBackgroundColor
+
+            New-RegEx -Name IsBright (
+                New-RegEx -Pattern '10' -Name IsBackgroundColor
+            )
+        ) |
+        New-RegEx -Pattern '[0-7]' -Name ColorNumber |
+        New-RegEx -LiteralCharacter 'm'
+    ) -Name Color | #>   
     Set-Content -Path (Join-Path $myRoot $myName)

--- a/RegEx/ANSI/4BitColor.regex.txt
+++ b/RegEx/ANSI/4BitColor.regex.txt
@@ -1,4 +1,8 @@
 # Matches an ANSI 3 or 4-bit color
 \e # An Escape
 \[ # Followed by a bracket
-(?<Color>(?<IsBright>1)?\;?(?<ForegroundColor>3[0-7])?(?(ForegroundColor)(m)|((?<BackgroundColor>4[0-7])m)))
+(?<Color>(?>
+  (?<IsBright>1)?\;{0,1}(?<IsForegroundColor>3)  |
+  (?<IsBright>(?<IsForegroundColor>9))  |
+  (?<IsBright>1)?\;{0,1}(?<IsBackgroundColor>4)  |
+  (?<IsBright>(?<IsBackgroundColor>10)))(?<ColorNumber>[0-7])m)

--- a/RegEx/ANSI/8BitColor.regex.source.ps1
+++ b/RegEx/ANSI/8BitColor.regex.source.ps1
@@ -4,7 +4,12 @@ $myRoot = $MyInvocation.MyCommand.ScriptBlock.File | Split-Path
 New-RegEx -Description "Matches an ANSI 8-bit color" -Modifier IgnoreCase -Not |
     New-RegEx -CharacterClass Escape -Comment 'An Escape' |
     New-RegEx -LiteralCharacter '[' -Comment 'Followed by a bracket' |
-    New-RegEx -Pattern '38;5;' |
+    New-RegEx -Atomic -Or @(
+        New-RegEx -Pattern '38' -Name IsForegroundColor
+        New-RegEx -Pattern '48' -Name IsBackgroundColor
+        New-RegEx -Pattern '58' -Name IsUnderlineColor
+    ) |
+    New-RegEx -Pattern ';5;' |
     New-RegEx -Name Color -Pattern (
         New-RegEx -Atomic -Or @(            
             New-Regex -Name StandardColor -Pattern '[0-7]' -Comment '0 -7 are standard colors' |

--- a/RegEx/ANSI/8BitColor.regex.txt
+++ b/RegEx/ANSI/8BitColor.regex.txt
@@ -1,7 +1,10 @@
-# Matches an ANSI 8 bit color
+# Matches an ANSI 8-bit color
 (?-i)\e                                                    # An Escape
 \[                                                         # Followed by a bracket
-38;5;(?<Color>(?>
+(?>
+  (?<IsForegroundColor>38)  |
+  (?<IsBackgroundColor>48)  |
+  (?<IsUnderlineColor>58));5;(?<Color>(?>
   (?<StandardColor>[0-7])                                  # 0 -7 are standard colors
 m  |
   (?<BrightColor>(?>[8-9]|1[0-5]))                         # 8-15 are bright colors

--- a/RegEx/ANSI/ANSI.tests.ps1
+++ b/RegEx/ANSI/ANSI.tests.ps1
@@ -1,0 +1,27 @@
+describe 'Irregular and ANSI' {
+    it 'Can match any ANSI sequence' {
+        "$([char]0x1b)[0m" | ?<ANSI_Code> | Select-Object -ExpandProperty Length | Should -be 4
+
+        "$([char]0x1b)[1;3;5,~" | ?<ANSI_Code> | Select-Object -ExpandProperty Length | Should -be 9
+    }
+    context 'ANSI Colors' {
+        it 'Can Match a 4-bit color' {
+            $x = "$([char]0x1b)[32m" | ?<ANSI_4BitColor> -Extract
+            $x.ColorNumber | Should -Be 2
+            $x.IsForegroundColor | Should -Be 3
+        }        
+
+        it 'Can Match a 24-bit color' {
+            $x = "$([char]0x1b)[38;2;255;100;0m" | ?<ANSI_24BitColor> -Extract
+            $x.Red | Should -be 255
+            $x.Green | Should -be 100
+            $x.Blue | Should -be 0
+        }
+    }
+
+    context 'ANSI Styles' {
+        it 'Can Match ANSI Styles' {
+            @("$([char]0x1b)[3m Italics $([char]0x1b)[23m" | ?<ANSI_Style>).Count | Should -be 2
+        }
+    }
+}

--- a/RegEx/ANSI/README.md
+++ b/RegEx/ANSI/README.md
@@ -7,7 +7,7 @@ Note:  Using these regular expressions in the terminal may result in awkward out
 |------------------------------------------------|-------------------------------------------------------------|----------------------------------------|
 |[?<ANSI_24BitColor>](24BitColor.regex.txt)      |Matches an ANSI 24-bit color                                 |[source](24BitColor.regex.source.ps1)   |
 |[?<ANSI_4BitColor>](4BitColor.regex.txt)        |Matches an ANSI 3 or 4-bit color                             |[source](4BitColor.regex.source.ps1)    |
-|[?<ANSI_8BitColor>](8BitColor.regex.txt)        |Matches an ANSI 8 bit color                                  |[source](8BitColor.regex.source.ps1)    |
+|[?<ANSI_8BitColor>](8BitColor.regex.txt)        |Matches an ANSI 8-bit color                                  |[source](8BitColor.regex.source.ps1)    |
 |[?<ANSI_Blink>](Blink.regex.txt)                |Matches ANSI Blink Start or End                              |[source](Blink.regex.source.ps1)        |
 |[?<ANSI_Bold>](Bold.regex.txt)                  |Matches an ANSI Bold Start or End                            |[source](Bold.regex.source.ps1)         |
 |[?<ANSI_Code>](Code.regex.txt)                  |Matches an ANSI escape code                                  |[source](Code.regex.source.ps1)         |

--- a/RegEx/ANSI/README.md
+++ b/RegEx/ANSI/README.md
@@ -20,6 +20,7 @@ Note:  Using these regular expressions in the terminal may result in awkward out
 |[?<ANSI_Note>](Note.regex.txt)                  |Matches an ANSI VT520 Note                                   |[source](Note.regex.source.ps1)         |
 |[?<ANSI_Reset>](Reset.regex.txt)                |Matches an ANSI Reset (this clears formatting)               |[source](Reset.regex.source.ps1)        |
 |[?<ANSI_Strikethrough>](Strikethrough.regex.txt)|Matches ANSI Strikethrough Start or End                      |[source](Strikethrough.regex.source.ps1)|
+|[?<ANSI_Style>](Style.regex.txt)                |Matches an ANSI style (color or text option)                 |[source](Style.regex.source.ps1)        |
 |[?<ANSI_Underline>](Underline.regex.txt)        |Matches ANSI Underline/DoubleUnderline Start or Underline End|[source](Underline.regex.source.ps1)    |
 
 

--- a/RegEx/ANSI/Style.regex.source.ps1
+++ b/RegEx/ANSI/Style.regex.source.ps1
@@ -10,7 +10,7 @@ New-RegEx -Description "Matches an ANSI style (color or text option)" |
         New-Regex -Pattern '?<ANSI_Italic>'
         New-Regex -Pattern '?<ANSI_Invert>'
         New-Regex -Pattern '?<ANSI_Hide>'
-        New-Regex -Pattern '?<ANSI_Strikethru>'
+        New-Regex -Pattern '?<ANSI_Strikethrough>'
         New-Regex -Pattern '?<ANSI_Underline>'
         New-RegEx -Pattern '?<ANSI_24BitColor>'
         New-RegEx -Pattern '?<ANSI_8BitColor>'

--- a/RegEx/ANSI/Style.regex.txt
+++ b/RegEx/ANSI/Style.regex.txt
@@ -1,122 +1,141 @@
 # Matches an ANSI style (color or text option)
 (?>
   (?<ANSI_Reset>
-\e                                                            # An Escape
-\[                                                            # Followed by a bracket
-(?<Reset>0m)                                                  # 0m indicates reset
+\e                                                                                     # An Escape
+\[                                                                                     # Followed by a bracket
+(?<Reset>0m)                                                                           # 0m indicates reset
 
 )
   |
   (?<ANSI_Bold>
-\e                                                            # An Escape
-\[                                                            # Followed by a bracket
+\e                                                                                     # An Escape
+\[                                                                                     # Followed by a bracket
 (?>
   (?<BoldStart>1m)  |
   (?<BoldEnd>22m))
 )
   |
   (?<ANSI_Blink>
-\e                                                            # An Escape
-\[                                                            # Followed by a bracket
+\e                                                                                     # An Escape
+\[                                                                                     # Followed by a bracket
 (?>
   (?>
-  (?<BlinkStart>(?<BlinkSlow>5m)                              # 5m starts a slow blink
+  (?<BlinkStart>(?<BlinkSlow>5m)                                                       # 5m starts a slow blink
     |
-    (?<BlinkFast>6m)                                          # 6m starts a slow blink
+    (?<BlinkFast>6m)                                                                   # 6m starts a slow blink
 ))  |
-  (?<BlinkEnd>25m)                                            # 25m stops blinks
+  (?<BlinkEnd>25m)                                                                     # 25m stops blinks
 )
 )
   |
   (?<ANSI_Faint>
-\e                                                            # An Escape
-\[                                                            # Followed by a bracket
+\e                                                                                     # An Escape
+\[                                                                                     # Followed by a bracket
 (?>
-  (?<FaintStart>2m)                                           # 2m starts faint
+  (?<FaintStart>2m)                                                                    # 2m starts faint
   |
-  (?<FaintEnd>22m)                                            # 22m stops faint
+  (?<FaintEnd>22m)                                                                     # 22m stops faint
 )
 )
   |
   (?<ANSI_Italic>
-\e                                                            # An Escape
-\[                                                            # Followed by a bracket
+\e                                                                                     # An Escape
+\[                                                                                     # Followed by a bracket
 (?>
-  (?<ItalicStart>3m)                                          # 3m starts italic
+  (?<ItalicStart>3m)                                                                   # 3m starts italic
   |
-  (?<ItalicEnd>23m)                                           # 23m stops italic
+  (?<ItalicEnd>23m)                                                                    # 23m stops italic
 )
 )
   |
   (?<ANSI_Invert>
-\e                                                            # An Escape
-\[                                                            # Followed by a bracket
+\e                                                                                     # An Escape
+\[                                                                                     # Followed by a bracket
 (?>
-  (?<InvertStart>7m)                                          # 7m starts invert
+  (?<InvertStart>7m)                                                                   # 7m starts invert
   |
-  (?<InvertEnd>27m)                                           # 27m stops invert
+  (?<InvertEnd>27m)                                                                    # 27m stops invert
 )
 )
   |
   (?<ANSI_Hide>
-\e                                                            # An Escape
-\[                                                            # Followed by a bracket
+\e                                                                                     # An Escape
+\[                                                                                     # Followed by a bracket
 (?>
-  (?<HideStart>8m)                                            # 8m starts hide
+  (?<HideStart>8m)                                                                     # 8m starts hide
   |
-  (?<HideEnd>28m)                                             # 28m stops hide
+  (?<HideEnd>28m)                                                                      # 28m stops hide
 )
 )
   |
-  ?<ANSI_Strikethru>  |
+  (?<ANSI_Strikethrough>
+\e                                                                                     # An Escape
+\[                                                                                     # Followed by a bracket
+(?>
+  (?<StrikethroughStart>9m)                                                            # 9m starts Strikethrough
+  |
+  (?<StrikethroughEnd>29m)                                                             # 29m stops Strikethrough
+)
+)
+  |
   (?<ANSI_Underline>
-\e                                                            # An Escape
-\[                                                            # Followed by a bracket
+\e                                                                                     # An Escape
+\[                                                                                     # Followed by a bracket
 (?>
-  (?<UnderlineStart>4m)                                       # 4m starts underline
+  (?<UnderlineStart>4m)                                                                # 4m starts underline
   |
-  (?<DoubleUnderlineStart>21m)                                # 21m start a double underline
+  (?<DoubleUnderlineStart>21m)                                                         # 21m start a double underline
   |
-  (?<UnderlineEnd>24m)                                        # 24m stops underline
+  (?<UnderlineEnd>24m)                                                                 # 24m stops underline
 )
 )
   |
   (?<ANSI_24BitColor>
-(?-i)\e                                                       # An Escape
-\[                                                            # Followed by a bracket
-38;2;(?<Color>(?<Red>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))   # Red is the first 0-255 value
-;(?<Red>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                # Green is the second 0-255 value
-;(?<Blue>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))               # Blue is the third 0-255 value
+(?-i)\e                                                                                # An Escape
+\[                                                                                     # Followed by a bracket
+(?>
+  (?<IsForegroundColor>38)  |
+  (?<IsBackgroundColor>48)  |
+  (?<IsUnderlineColor>58));2;(?<Color>(?<Red>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))    # Red is the first 0-255 value
+;(?<Green>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                                       # Green is the second 0-255 value
+;(?<Blue>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                                        # Blue is the third 0-255 value
 m)
 )
   |
   (?<ANSI_8BitColor>
-(?-i)\e                                                       # An Escape
-\[                                                            # Followed by a bracket
-38;5;(?<Color>(?>
-  (?<StandardColor>[0-7])                                     # 0 -7 are standard colors
+(?-i)\e                                                                                # An Escape
+\[                                                                                     # Followed by a bracket
+(?>
+  (?<IsForegroundColor>38)  |
+  (?<IsBackgroundColor>48)  |
+  (?<IsUnderlineColor>58));5;(?<Color>(?>
+  (?<StandardColor>[0-7])                                                              # 0 -7 are standard colors
 m  |
-  (?<BrightColor>(?>[8-9]|1[0-5]))                            # 8-15 are bright colors
+  (?<BrightColor>(?>[8-9]|1[0-5]))                                                     # 8-15 are bright colors
 m  |
-  (?<CubeColor>(?>[0-2][0-3][0-1]|[0-1]\d\d|\d{1,2}))         # 16-231  are cubed colors
+  (?<CubeColor>(?>[0-2][0-3][0-1]|[0-1]\d\d|\d{1,2}))                                  # 16-231  are cubed colors
 m  |
-  (?<GrayscaleColor>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))    # 232-255 are grayscales
+  (?<GrayscaleColor>(?>[0-2][0-5][0-5]|[0-1]\d\d|\d{1,2}))                             # 232-255 are grayscales
 m))
 )
   |
   (?<ANSI_4BitColor>
-\e                                                            # An Escape
-\[                                                            # Followed by a bracket
-(?<Color>(?<IsBright>1)?\;?(?<ForegroundColor>3[0-7])?(?(ForegroundColor)(m)|((?<BackgroundColor>4[0-7])m)))
+\e                                                                                     # An Escape
+\[                                                                                     # Followed by a bracket
+(?<Color>(?>
+  (?<IsBright>1)?\;{0,1}(?<IsForegroundColor>3)  |
+  (?<IsBright>(?<IsForegroundColor>9))  |
+  (?<IsBright>1)?\;{0,1}(?<IsBackgroundColor>4)  |
+  (?<IsBright>(?<IsBackgroundColor>10)))(?<ColorNumber>[0-7])m)
 )
   |
   (?<ANSI_DefaultColor>
-(?-i)\e                                                       # An Escape
-\[                                                            # Followed by a bracket
+(?-i)\e                                                                                # An Escape
+\[                                                                                     # Followed by a bracket
 (?<Color>(?>
-  (?<DefaultForeground>39)                                    # 39 Represents the default foreground color
+  (?<DefaultForeground>39)                                                             # 39 Represents the default foreground color
 m  |
-  (?<DefaultForeground>49)                                    # 49 Represents the default background color
+  (?<DefaultForeground>49)                                                             # 49 Represents the default background color
 m))
 )
 )

--- a/RegEx/PowerShell/README.md
+++ b/RegEx/PowerShell/README.md
@@ -9,6 +9,7 @@ They are designed to work in _most_ scenarios and to offer an alternative way to
 |----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|------------------------------------------|
 |[?<PowerShell_Attribute>](Attribute.regex.txt)            |Matches a PowerShell attribute declaration                                                                    |
 |[?<PowerShell_AttributeValue>](AttributeValue.regex.txt)  |This expression extracts the key/value pairs from a PowerShell attribute body (the content within parenthesis)|
+|[?<PowerShell_Function>](Function.regex.txt)              |Matches PowerShell functions                                                                                  |
 |[?<PowerShell_HelpField>](HelpField.regex.ps1)            |Matches specific fields from inline help<br/>                                                                |[generator](HelpField.regex.ps1)          |
 |[?<PowerShell_Invoke_Variable>](Invoke_Variable.regex.txt)|Matches any time a variable is invoked (with the . or & operator)                                             |[source](Invoke_Variable.regex.source.ps1)|
 |[?<PowerShell_ParameterSet>](ParameterSet.regex.txt)      |Matches PowerShell ParameterSets (in [Parameter] and [CmdletBinding] attributes)                              |[source](ParameterSet.regex.source.ps1)   |

--- a/SavedPatterns.md
+++ b/SavedPatterns.md
@@ -4,7 +4,7 @@ Irregular includes 129 regular expressions
 |:---|:----------|:----------|
 |[ANSI_24BitColor](/RegEx/ANSI/24BitColor.regex.txt)|Matches an ANSI 24-bit color|False|
 |[ANSI_4BitColor](/RegEx/ANSI/4BitColor.regex.txt)|Matches an ANSI 3 or 4-bit color|False|
-|[ANSI_8BitColor](/RegEx/ANSI/8BitColor.regex.txt)|Matches an ANSI 8 bit color|False|
+|[ANSI_8BitColor](/RegEx/ANSI/8BitColor.regex.txt)|Matches an ANSI 8-bit color|False|
 |[ANSI_Blink](/RegEx/ANSI/Blink.regex.txt)|Matches ANSI Blink Start or End|False|
 |[ANSI_Bold](/RegEx/ANSI/Bold.regex.txt)|Matches an ANSI Bold Start or End|False|
 |[ANSI_Code](/RegEx/ANSI/Code.regex.txt)|Matches an ANSI escape code|False|

--- a/SavedPatterns.md
+++ b/SavedPatterns.md
@@ -1,5 +1,5 @@
 ### Irregular Patterns
-Irregular includes 128 regular expressions
+Irregular includes 129 regular expressions
 |Name|Description|IsGenerator|
 |:---|:----------|:----------|
 |[ANSI_24BitColor](/RegEx/ANSI/24BitColor.regex.txt)|Matches an ANSI 24-bit color|False|
@@ -103,6 +103,7 @@ Irregular includes 128 regular expressions
 |[PII_Unredacted_SSN](/RegEx/PII/Unredacted_SSN.regex.txt)|Matches Unredacted Social Security Numbers|False|
 |[PowerShell_Attribute](/RegEx/PowerShell/Attribute.regex.txt)|Matches a PowerShell attribute declaration|False|
 |[PowerShell_AttributeValue](/RegEx/PowerShell/AttributeValue.regex.txt)|This expression extracts the key/value pairs from a PowerShell attribute body (the content within parenthesis)|False|
+|[PowerShell_Function](/RegEx/PowerShell/Function.regex.txt)|Matches PowerShell functions|False|
 |[PowerShell_HelpField](/RegEx/PowerShell/HelpField.regex.ps1)|Matches specific fields from inline help|True|
 |[PowerShell_Invoke_Variable](/RegEx/PowerShell/Invoke_Variable.regex.txt)|Matches any time a variable is invoked (with the . or & operator)|False|
 |[PowerShell_ParameterSet](/RegEx/PowerShell/ParameterSet.regex.txt)|Matches PowerShell ParameterSets (in [Parameter] and [CmdletBinding] attributes)|False|

--- a/SavedPatterns.md
+++ b/SavedPatterns.md
@@ -1,5 +1,5 @@
 ### Irregular Patterns
-Irregular includes 129 regular expressions
+Irregular includes 130 regular expressions
 |Name|Description|IsGenerator|
 |:---|:----------|:----------|
 |[ANSI_24BitColor](/RegEx/ANSI/24BitColor.regex.txt)|Matches an ANSI 24-bit color|False|
@@ -17,6 +17,7 @@ Irregular includes 129 regular expressions
 |[ANSI_Note](/RegEx/ANSI/Note.regex.txt)|Matches an ANSI VT520 Note|False|
 |[ANSI_Reset](/RegEx/ANSI/Reset.regex.txt)|Matches an ANSI Reset (this clears formatting)|False|
 |[ANSI_Strikethrough](/RegEx/ANSI/Strikethrough.regex.txt)|Matches ANSI Strikethrough Start or End|False|
+|[ANSI_Style](/RegEx/ANSI/Style.regex.txt)|Matches an ANSI style (color or text option)|False|
 |[ANSI_Underline](/RegEx/ANSI/Underline.regex.txt)|Matches ANSI Underline/DoubleUnderline Start or Underline End|False|
 |[ArithmeticOperator](/RegEx/ArithmeticOperator.regex.txt)|Simple Arithmetic Operators|False|
 |[BalancedBrackets](/RegEx/BalancedBrackets.regex.txt)|Matches content in brackets, as long as it is balanced|False|

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.3:
+* ANSI Improvements:
+  * Fixed ?<ANSI_Style> (Fixes #143)
+  * ?<ANSI_4BitColor> now supports bright ranges (Fixes #145)
+  * ?<ANSI_8BitColor>/?<ANSI_24BitColor> now supports background colors (Fixes #144)
+  * ?<ANSI_8BitColor>/?<ANSI_24BitColor> now supports underline colors (Fixes #146)
+---
+
 ## 0.7.2:
 * Lots More ANSI support:
   * ?<ANSI_Bold> (Fixes #131)

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,3 +154,4 @@ string: 'hello'
 
 
 
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Once you understand some basics of that syntax, regular expressions become a lot
 3. A Regex can have comments! ( # Like this in .NET  ( or like (?#this comment) in ECMAScript ) ).
 4. You don't have to do it all in one expression! 
 
-Irregular comes with 128 useful [named expressions](SavedPatterns.md), and lets you create more.
+Irregular comes with 129 useful [named expressions](SavedPatterns.md), and lets you create more.
 
 To see the expressions that ship with Irregular, run:
 
@@ -150,8 +150,6 @@ string: 'hello'
         }
     }
 ~~~
-
-
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 <h2>Regular Expressions made Strangely Simple</h2>
 <h3>A PowerShell module that helps you understand, use, and build Regular Expressions.</h3>
 <h4>
-<a href='https://github.com/StartAutomating/Irregular/releases/tag/v0.7.2'>v 0.7.2 </a>
+<a href='https://github.com/StartAutomating/Irregular/releases/tag/v0.7.3'>v 0.7.3 </a>
 </h4>
 <a href='https://www.powershellgallery.com/packages/Irregular/'>
 <img src='https://img.shields.io/powershellgallery/dt/Irregular' />
@@ -150,8 +150,6 @@ string: 'hello'
         }
     }
 ~~~
-
-
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,3 +153,4 @@ string: 'hello'
 
 
 
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Once you understand some basics of that syntax, regular expressions become a lot
 3. A Regex can have comments! ( # Like this in .NET  ( or like (?#this comment) in ECMAScript ) ).
 4. You don't have to do it all in one expression! 
 
-Irregular comes with 129 useful [named expressions](SavedPatterns.md), and lets you create more.
+Irregular comes with 130 useful [named expressions](SavedPatterns.md), and lets you create more.
 
 To see the expressions that ship with Irregular, run:
 
@@ -150,8 +150,6 @@ string: 'hello'
         }
     }
 ~~~
-
-
 
 
 

--- a/docs/SavedPatterns.md
+++ b/docs/SavedPatterns.md
@@ -1,10 +1,10 @@
 ### Irregular Patterns
-Irregular includes 128 regular expressions
+Irregular includes 129 regular expressions
 |Name|Description|IsGenerator|
 |:---|:----------|:----------|
 |[ANSI_24BitColor](/RegEx/ANSI/24BitColor.regex.txt)|Matches an ANSI 24-bit color|False|
 |[ANSI_4BitColor](/RegEx/ANSI/4BitColor.regex.txt)|Matches an ANSI 3 or 4-bit color|False|
-|[ANSI_8BitColor](/RegEx/ANSI/8BitColor.regex.txt)|Matches an ANSI 8 bit color|False|
+|[ANSI_8BitColor](/RegEx/ANSI/8BitColor.regex.txt)|Matches an ANSI 8-bit color|False|
 |[ANSI_Blink](/RegEx/ANSI/Blink.regex.txt)|Matches ANSI Blink Start or End|False|
 |[ANSI_Bold](/RegEx/ANSI/Bold.regex.txt)|Matches an ANSI Bold Start or End|False|
 |[ANSI_Code](/RegEx/ANSI/Code.regex.txt)|Matches an ANSI escape code|False|
@@ -103,6 +103,7 @@ Irregular includes 128 regular expressions
 |[PII_Unredacted_SSN](/RegEx/PII/Unredacted_SSN.regex.txt)|Matches Unredacted Social Security Numbers|False|
 |[PowerShell_Attribute](/RegEx/PowerShell/Attribute.regex.txt)|Matches a PowerShell attribute declaration|False|
 |[PowerShell_AttributeValue](/RegEx/PowerShell/AttributeValue.regex.txt)|This expression extracts the key/value pairs from a PowerShell attribute body (the content within parenthesis)|False|
+|[PowerShell_Function](/RegEx/PowerShell/Function.regex.txt)|Matches PowerShell functions|False|
 |[PowerShell_HelpField](/RegEx/PowerShell/HelpField.regex.ps1)|Matches specific fields from inline help|True|
 |[PowerShell_Invoke_Variable](/RegEx/PowerShell/Invoke_Variable.regex.txt)|Matches any time a variable is invoked (with the . or & operator)|False|
 |[PowerShell_ParameterSet](/RegEx/PowerShell/ParameterSet.regex.txt)|Matches PowerShell ParameterSets (in [Parameter] and [CmdletBinding] attributes)|False|

--- a/docs/SavedPatterns.md
+++ b/docs/SavedPatterns.md
@@ -1,5 +1,5 @@
 ### Irregular Patterns
-Irregular includes 129 regular expressions
+Irregular includes 130 regular expressions
 |Name|Description|IsGenerator|
 |:---|:----------|:----------|
 |[ANSI_24BitColor](/RegEx/ANSI/24BitColor.regex.txt)|Matches an ANSI 24-bit color|False|
@@ -17,6 +17,7 @@ Irregular includes 129 regular expressions
 |[ANSI_Note](/RegEx/ANSI/Note.regex.txt)|Matches an ANSI VT520 Note|False|
 |[ANSI_Reset](/RegEx/ANSI/Reset.regex.txt)|Matches an ANSI Reset (this clears formatting)|False|
 |[ANSI_Strikethrough](/RegEx/ANSI/Strikethrough.regex.txt)|Matches ANSI Strikethrough Start or End|False|
+|[ANSI_Style](/RegEx/ANSI/Style.regex.txt)|Matches an ANSI style (color or text option)|False|
 |[ANSI_Underline](/RegEx/ANSI/Underline.regex.txt)|Matches ANSI Underline/DoubleUnderline Start or Underline End|False|
 |[ArithmeticOperator](/RegEx/ArithmeticOperator.regex.txt)|Simple Arithmetic Operators|False|
 |[BalancedBrackets](/RegEx/BalancedBrackets.regex.txt)|Matches content in brackets, as long as it is balanced|False|


### PR DESCRIPTION
## 0.7.3:
* ANSI Improvements:
  * Fixed ?<ANSI_Style> (Fixes #143)
  * ?<ANSI_4BitColor> now supports bright ranges (Fixes #145)
  * ?<ANSI_8BitColor>/?<ANSI_24BitColor> now supports background colors (Fixes #144)
  * ?<ANSI_8BitColor>/?<ANSI_24BitColor> now supports underline colors (Fixes #146)
---
